### PR TITLE
fix: Fix localeKey attribute on shouldBeStrict() option

### DIFF
--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -30,6 +30,9 @@ class Country extends Model
     /* Translatable ForeignKey */
     public $translationForeignKey = 'lc_country_id';
 
+    /* @property-read string $localeKey */
+    public string $localeKey;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -77,6 +80,12 @@ class Country extends Model
         'coordinates_limit' => Json::class,
         'visible' => 'boolean',
     ];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->localeKey = config('translatable.locale_key', 'locale');
+        parent::__construct($attributes);
+    }
 
     /**
      * The "booting" method of the model.

--- a/src/models/CountryGeographical.php
+++ b/src/models/CountryGeographical.php
@@ -18,6 +18,9 @@ class CountryGeographical extends Model
      */
     protected $table = 'lc_countries_geographical';
 
+    /* @property-read string $localeKey */
+    public string $localeKey;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -41,6 +44,12 @@ class CountryGeographical extends Model
         'properties' => Json::class,
         'geometry' => Json::class,
     ];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->localeKey = config('translatable.locale_key', 'locale');
+        parent::__construct($attributes);
+    }
 
     public static function boot()
     {

--- a/src/models/CountryRegion.php
+++ b/src/models/CountryRegion.php
@@ -29,6 +29,9 @@ class CountryRegion extends Model
     /* Translatable ForeignKey */
     public $translationForeignKey = 'lc_region_id';
 
+    /* @property-read string $localeKey */
+    public string $localeKey;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -37,6 +40,12 @@ class CountryRegion extends Model
     protected $fillable = [
         'uuid',
     ];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->localeKey = config('translatable.locale_key', 'locale');
+        parent::__construct($attributes);
+    }
 
     public static function boot()
     {


### PR DESCRIPTION
Fix Issue #27  [attribute [localeKey] either does not exist" error with using shouldBeStrict() in Laravel 11](https://github.com/lwwcas/laravel-countries/issues/27)