### PR TITLE
Add custom database driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lwwcas/laravel-countries",
+    "name": "mixx-bv/laravel-countries",
     "description": "A comprehensive package for managing country data in Laravel applications, including multilingual support, geographic coordinates, and detailed metadata for seamless integration with Laravel.",
     "homepage": "https://lwwcas.github.io/laravel-countries/",
     "type": "library",

--- a/src/Abstract/CountryModel.php
+++ b/src/Abstract/CountryModel.php
@@ -4,10 +4,12 @@ namespace Lwwcas\LaravelCountries\Abstract;
 
 use Illuminate\Database\Eloquent\Model;
 use Lwwcas\LaravelCountries\Models\Concerns\HasConfigs;
+use Lwwcas\LaravelCountries\Models\Concerns\HasConnection;
 
 abstract class CountryModel extends Model
 {
-    use HasConfigs;
+    use HasConfigs,
+        HasConnection;
 
     /**
      * @property-read string $localeKey

--- a/src/Commands/WCountriesRunLanguagesSeeds.php
+++ b/src/Commands/WCountriesRunLanguagesSeeds.php
@@ -37,7 +37,7 @@ class WCountriesRunLanguagesSeeds extends Command
      */
     public function handle()
     {
-        if (Schema::hasTable('lc_countries') == false || Schema::hasTable('lc_regions') == false) {
+        if (Schema::connection('w-countries.driver')->hasTable('lc_countries') == false || Schema::connection('w-countries.driver')->hasTable('lc_regions') == false) {
             $this->error('First install the countries and regions tables.');
             $this->info('Run php artisan w-countries:install for the structure to be installed first.');
             $this->newLine();

--- a/src/Database/Seeders/RegionsSeeder.php
+++ b/src/Database/Seeders/RegionsSeeder.php
@@ -53,7 +53,7 @@ class RegionsSeeder extends Seeder
             ],
         ];
 
-        if (Schema::hasTable('lc_regions') == false) {
+        if (Schema::connection(config('w-countries.driver'))->hasTable('lc_regions') == false) {
             return;
         }
 

--- a/src/Database/migrations/create_lc_countries_coordinates_table.php
+++ b/src/Database/migrations/create_lc_countries_coordinates_table.php
@@ -14,7 +14,7 @@ return new class() extends Migration
      */
     public function up()
     {
-        Schema::create('lc_countries_coordinates', function (Blueprint $table) {
+        Schema::connection(config('w-countries.driver'))->create('lc_countries_coordinates', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('lc_country_id')->unsigned();
             $table->string('latitude')->nullable();
@@ -35,6 +35,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('lc_countries_coordinates');
+        Schema::connection(config('w-countries.driver'))->dropIfExists('lc_countries_coordinates');
     }
 };

--- a/src/Database/migrations/create_lc_countries_extras_table.php
+++ b/src/Database/migrations/create_lc_countries_extras_table.php
@@ -13,7 +13,7 @@ return new class() extends Migration
      */
     public function up()
     {
-        Schema::create('lc_countries_extras', function (Blueprint $table) {
+        Schema::connection(config('w-countries.driver'))->create('lc_countries_extras', function (Blueprint $table) {
             $table->increments('id')->comment('Primary key: auto-incremented extra information ID.');
             $table->integer('lc_country_id')->unsigned()->comment('Foreign key linking to the lc_countries table.');
 
@@ -38,6 +38,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('lc_countries_extras');
+        Schema::connection(config('w-countries.driver'))->dropIfExists('lc_countries_extras');
     }
 };

--- a/src/Database/migrations/create_lc_countries_geographical_table.php
+++ b/src/Database/migrations/create_lc_countries_geographical_table.php
@@ -13,7 +13,7 @@ return new class() extends Migration
      */
     public function up()
     {
-        Schema::create('lc_countries_geographical', function (Blueprint $table) {
+        Schema::connection(config('w-countries.driver'))->create('lc_countries_geographical', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('lc_country_id')->unsigned();
             $table->string('type');
@@ -32,6 +32,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('lc_countries_geographical');
+        Schema::connection(config('w-countries.driver'))->dropIfExists('lc_countries_geographical');
     }
 };

--- a/src/Database/migrations/create_lc_countries_table.php
+++ b/src/Database/migrations/create_lc_countries_table.php
@@ -13,7 +13,7 @@ return new class() extends Migration
      */
     public function up()
     {
-        Schema::create('lc_countries', function (Blueprint $table) {
+        Schema::connection(config('w-countries.driver'))->create('lc_countries', function (Blueprint $table) {
             $table->increments('id')->comment('Primary key: auto-incremented country ID.');
             $table->tinyInteger('lc_region_id')->unsigned()->comment('Foreign key referencing the region this country belongs to.');
             $table->ulid('uid')->unique()->comment('Unique ULID for the country, sortable and lexicographically unique.');
@@ -67,6 +67,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('lc_countries');
+        Schema::connection(config('w-countries.driver'))->dropIfExists('lc_countries');
     }
 };

--- a/src/Database/migrations/create_lc_countries_translations_table.php
+++ b/src/Database/migrations/create_lc_countries_translations_table.php
@@ -13,7 +13,7 @@ return new class() extends Migration
      */
     public function up()
     {
-        Schema::create('lc_countries_translations', function (Blueprint $table) {
+        Schema::connection(config('w-countries.driver'))->create('lc_countries_translations', function (Blueprint $table) {
             $table->id('id');
             $table->integer('lc_country_id')->unsigned();
             $table->string('name');
@@ -33,6 +33,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('lc_countries_translations');
+        Schema::connection(config('w-countries.driver'))->dropIfExists('lc_countries_translations');
     }
 };

--- a/src/Database/migrations/create_lc_region_translations_table.php
+++ b/src/Database/migrations/create_lc_region_translations_table.php
@@ -13,7 +13,7 @@ return new class() extends Migration
      */
     public function up()
     {
-        Schema::create('lc_region_translations', function (Blueprint $table) {
+        Schema::connection(config('w-countries.driver'))->create('lc_region_translations', function (Blueprint $table) {
             $table->tinyIncrements('id');
             $table->tinyInteger('lc_region_id')->unsigned();
             $table->string('name');
@@ -33,6 +33,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('lc_region_translations');
+        Schema::connection(config('w-countries.driver'))->dropIfExists('lc_region_translations');
     }
 };

--- a/src/Database/migrations/create_lc_regions_table.php
+++ b/src/Database/migrations/create_lc_regions_table.php
@@ -13,7 +13,7 @@ return new class() extends Migration
      */
     public function up()
     {
-        Schema::create('lc_regions', function (Blueprint $table) {
+        Schema::connection(config('w-countries.driver'))->create('lc_regions', function (Blueprint $table) {
             $table->tinyIncrements('id');
             $table->string('iso_alpha_2', 10)->comment('ISO 3166-1 Alpha-2 code');
             $table->string('icao', 10)->comment('International Civil Aviation Organization (ICAO) region');
@@ -30,6 +30,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('lc_regions');
+        Schema::connection(config('w-countries.driver'))->dropIfExists('lc_regions');
     }
 };

--- a/src/Models/Concerns/HasConnection.php
+++ b/src/Models/Concerns/HasConnection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lwwcas\LaravelCountries\Models\Concerns;
+
+
+trait HasConnection
+{
+    /**
+     * Return the name of the connection driver
+     *
+     * @return string
+     */
+
+    public function getConnectionName(): string
+    {
+        return config('w-countries.driver');
+    }
+
+}

--- a/src/Models/CountryRegion.php
+++ b/src/Models/CountryRegion.php
@@ -6,6 +6,7 @@ use Astrotomic\Translatable\Translatable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lwwcas\LaravelCountries\Abstract\CountryModel;
+use Lwwcas\LaravelCountries\Models\Concerns\HasConnection;
 use Lwwcas\LaravelCountries\Models\Concerns\HasTranslationGlobalScope;
 use Lwwcas\LaravelCountries\Models\Concerns\HasVisibleGlobalScope;
 use Lwwcas\LaravelCountries\Models\Concerns\HasWhereIso;
@@ -24,7 +25,8 @@ class CountryRegion extends CountryModel
         HasWhereName,
         HasWhereIso,
         HasWhereIsoAlpha2,
-        VisibleAttributes;
+        VisibleAttributes,
+        HasConnection;
 
     public $translationModel = CountryRegionTranslation::class;
 

--- a/src/Models/CountryRegionTranslation.php
+++ b/src/Models/CountryRegionTranslation.php
@@ -5,10 +5,12 @@ namespace Lwwcas\LaravelCountries\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Lwwcas\LaravelCountries\Models\Concerns\HasConnection;
 
 class CountryRegionTranslation extends Model
 {
-    use HasFactory;
+    use HasFactory,
+        HasConnection;
 
     /**
      * Indicates if the model should be timestamped.

--- a/src/Models/CountryTranslation.php
+++ b/src/Models/CountryTranslation.php
@@ -5,10 +5,12 @@ namespace Lwwcas\LaravelCountries\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Lwwcas\LaravelCountries\Models\Concerns\HasConnection;
 
 class CountryTranslation extends Model
 {
-    use HasFactory;
+    use HasFactory,
+        HasConnection;
 
     /**
      * Indicates if the model should be timestamped.

--- a/src/config/w-countries.php
+++ b/src/config/w-countries.php
@@ -13,4 +13,5 @@ return [
         'small_time' => Carbon::now()->addDays(7),
         'prefix' => null,
     ],
+    'driver' => env('DB_CONNECTION_COUNTRIES',config('database.default','mysql')),
 ];


### PR DESCRIPTION
I wanted the tables to be stored in a different database then the my main application.

This pull requests adds this functionality. You can now define in your .env file a key that defines the driver where to store the tables: DB_CONNECTION_COUNTRIES=
