### PR TITLE
 Fix PHP 8.4 deprecations

### DIFF
--- a/src/Facades/FlagEmoji.php
+++ b/src/Facades/FlagEmoji.php
@@ -52,7 +52,7 @@ final class FlagEmoji
      * @return Collection|FlagEmoji A Collection of all flag emoji attributes, or the flag emoji
      *                              attribute at the given key.
      */
-    public function get(string|int $flagKey = null): Collection|FlagEmoji
+    public function get(string|int|null $flagKey = null): Collection|FlagEmoji
     {
         if ($flagKey !== null) {
            return $this->on_data[$flagKey];

--- a/src/Trait/WithFlagColorBootstrap.php
+++ b/src/Trait/WithFlagColorBootstrap.php
@@ -16,7 +16,7 @@ trait WithFlagColorBootstrap
      *
      * @return string The gradient direction in degrees.
      */
-    protected function getGradientDirection(string $startsOn = null): string
+    protected function getGradientDirection(?string $startsOn = null): string
     {
         $gradientDirections = [
             'random' => null,
@@ -46,7 +46,7 @@ trait WithFlagColorBootstrap
      *
      * @return string|null The CSS gradient string or null if no colors are set.
      */
-    public function getFlagGradient(string $startsOn = null): string|null
+    public function getFlagGradient(?string $startsOn = null): string|null
     {
         $direction = $this->getGradientDirection($startsOn);
         $hexColors = $this->getFlagColorsHex();
@@ -68,7 +68,7 @@ trait WithFlagColorBootstrap
      * @return string|null The CSS gradient string or null if no colors are set.
      */
 
-    public function getCombinedFlagGradient(Country $otherCountry, string $startsOn = null): string|null
+    public function getCombinedFlagGradient(Country $otherCountry, ?string $startsOn = null): string|null
     {
         $thisColors = $this->getFlagColorsHex();
         $otherColors = $otherCountry->getFlagColorsHex();

--- a/src/Trait/WithLanguages.php
+++ b/src/Trait/WithLanguages.php
@@ -56,7 +56,7 @@ trait WithLanguages
      *
      * @return $this
      */
-    public function askToRunSeeds(array $languages = null): self
+    public function askToRunSeeds(?array $languages = null): self
     {
         if ($languages === null) {
             $languages = array_keys($this->languages);


### PR DESCRIPTION
As highlighted by @jonaaix in issue #52 this package is logging lots of deprecation warnings, due to implicitly marking parameter as nullable being deprecated in 8.4

Ref:
`[11-Feb-2026 16:37:02 UTC] PHP Deprecated: Lwwcas\LaravelCountries\Trait\WithLanguages::askToRunSeeds(): Implicitly marking parameter $languages as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/lwwcas/laravel-countries/src/Trait/WithLanguages.php on line 59`